### PR TITLE
Add Dockerfile and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log 
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:10
+WORKDIR /build
+RUN apt update
+RUN apt install ffmpeg libavahi-compat-libdnssd-dev python3-pip -y
+RUN pip3 install guessit
+COPY package*.json ./
+RUN npm install
+RUN npm i sqlite3
+COPY . .
+RUN npm run prepare
+RUN mkdir /etc/oblecto
+EXPOSE 8080 9131 9132
+CMD [ "node", "dist/bin/oblecto", "start" ]


### PR DESCRIPTION
Added a Dockerfile and .dockerignore so Oblecto can be used in docker


Instructions are included below

*Note: since the Web UI doesn't support all features with a sqlite-only backend at the moment, a `config.json` will need to be used for MySQL, or until a patch is applied. (defined in the "optional" step below)*

## Install Using Docker
Clone the repo using 
```
git clone --recurse-submodules https://github.com/robinp7720/Oblecto.git
```
After the clone is complete, change directories to the repo and build the container with the following
```
docker build -t oblecto .
```
After building, go to the directory where you want to store configuration files and assets

 *Optional:* edit/create `config.json` in the directory you plan on initializing Oblecto in, if you want to edit Oblecto configuration

Next, you can generate configuration files with 
```
docker run --rm -v "$PWD:/etc/oblecto" oblecto /bin/bash -c "node /build/dist/bin/oblecto init && node /build/dist/bin/oblecto init database"
```

After the files are generated, they will appear in your current directory, unless you changed `$PWD`

Lastly, the following following `docker-compose` configuration can be used, after changing all directories in the brackets.
```yaml
    oblecto:
        image: oblecto
        restart: unless-stopped
        ports:
            - "8080:8080"
            - "9131:9131"
            - "9132:9132"
        volumes:
            - "[movie directory]:/mnt/Movies/:ro"
            - "[show directory]:/mnt/Shows/:ro"
            - "[folder from init]:/etc/oblecto"
```

After starting the server you may need to create an account. This can be done with
```
docker-compose exec oblecto node /build/dist/bin/oblecto.js adduser [username] [password] [name] [email]
```
