### PR TITLE
Index media file streams

### DIFF
--- a/src/models/stream.js
+++ b/src/models/stream.js
@@ -1,0 +1,95 @@
+import {DataTypes, Model} from 'sequelize';
+
+export class Stream extends Model {
+}
+
+export const streamColumns = {
+    index: DataTypes.INTEGER,
+    codec_name: DataTypes.STRING,
+    profile: DataTypes.STRING,
+    codec_type: DataTypes.STRING,
+
+    codec_time_base: DataTypes.STRING,
+    codec_tag_string: DataTypes.STRING,
+
+    sample_fmt: DataTypes.STRING,
+    sample_rate: DataTypes.INTEGER,
+    bits_per_sample: DataTypes.INTEGER,
+
+    channels: DataTypes.INTEGER,
+    channel_layout: DataTypes.STRING,
+
+    width: DataTypes.INTEGER,
+    height: DataTypes.INTEGER,
+
+    coded_width: DataTypes.INTEGER,
+    coded_height: DataTypes.INTEGER,
+
+    has_b_frames: DataTypes.INTEGER,
+
+    sample_aspect_ratio: DataTypes.STRING,
+    display_aspect_ratio: DataTypes.STRING,
+    pix_fmt: DataTypes.STRING,
+
+    level: DataTypes.INTEGER,
+
+    color_range: DataTypes.STRING,
+    color_space: DataTypes.STRING,
+    color_transfer: DataTypes.STRING,
+    color_primaries: DataTypes.STRING,
+    chroma_location: DataTypes.STRING,
+
+    field_order: DataTypes.STRING,
+    timecode: DataTypes.INTEGER,
+
+    refs: DataTypes.INTEGER,
+
+    is_avc: DataTypes.BOOLEAN,
+    nal_length_size: DataTypes.INTEGER,
+
+    stream_id: DataTypes.STRING,
+
+    r_frame_rate: DataTypes.STRING,
+    avg_frame_rate: DataTypes.STRING,
+
+    time_base: DataTypes.STRING,
+
+    start_pts: DataTypes.BIGINT,
+    start_time: DataTypes.INTEGER,
+
+    duration_ts: DataTypes.BIGINT,
+    duration: DataTypes.INTEGER,
+
+    bit_rate: DataTypes.INTEGER,
+    max_bit_rate: DataTypes.INTEGER,
+    bits_per_raw_sample: DataTypes.INTEGER,
+    nb_frames: DataTypes.INTEGER,
+    nb_read_frames: DataTypes.INTEGER,
+    nb_read_packets: DataTypes.INTEGER,
+
+    disposition_default: DataTypes.INTEGER,
+    disposition_dub: DataTypes.INTEGER,
+    disposition_original: DataTypes.INTEGER,
+    disposition_comment: DataTypes.INTEGER,
+    disposition_lyrics: DataTypes.INTEGER,
+    disposition_karaoke: DataTypes.INTEGER,
+    disposition_forced: DataTypes.INTEGER,
+    disposition_hearing_impaired: DataTypes.INTEGER,
+    disposition_clean_effects: DataTypes.INTEGER,
+    disposition_attached_pic: DataTypes.INTEGER,
+    disposition_timed_thumbnails: DataTypes.INTEGER,
+
+    tags_language: DataTypes.STRING,
+    tags_title: DataTypes.STRING,
+
+    dmix_mode: DataTypes.INTEGER,
+    ltrt_cmixlev: DataTypes.INTEGER,
+    ltrt_surmixlev: DataTypes.INTEGER,
+    loro_cmixlev: DataTypes.INTEGER,
+    loro_surmixlev: DataTypes.INTEGER,
+
+    quarter_sample: DataTypes.BOOLEAN,
+    divx_packed: DataTypes.BOOLEAN,
+
+    side_data_type: DataTypes.STRING
+};

--- a/src/submodules/database.js
+++ b/src/submodules/database.js
@@ -12,6 +12,7 @@ import {SeriesSet, seriesSetColumns} from '../models/seriesSet';
 import {TrackMovie, trackMovieColumns} from '../models/trackMovie';
 import {TrackEpisode, trackEpisodesColumns} from '../models/trackEpisode';
 import {User, userColumns} from '../models/user';
+import {Stream, streamColumns} from '../models/stream';
 
 export function initDatabes() {
     let options = {
@@ -43,6 +44,7 @@ export function initDatabes() {
     Series.init(seriesColumns, {sequelize});
 
     File.init(fileColumns, {sequelize});
+    Stream.init(streamColumns, {sequelize});
 
     EpisodeFiles.init(episodeFilesColumns, {sequelize});
     MovieFiles.init(movieFileColumns, {sequelize});
@@ -70,6 +72,8 @@ export function initDatabes() {
 
     File.belongsToMany(Episode, {through: EpisodeFiles});
     File.belongsToMany(Movie, {through: MovieFiles});
+    Stream.belongsTo(File);
+    File.hasMany(Stream);
 
     TrackEpisode.belongsTo(User);
     TrackEpisode.belongsTo(Episode);


### PR DESCRIPTION
Index the streams within video flies so we can reference them later during playback session creation. Eg: language selection and possibly auto selecting an audio stream codec which can be played without transcoding