### PR TITLE
Fix primary stream selection logic

### DIFF
--- a/src/lib/updaters/files/FileUpdater.js
+++ b/src/lib/updaters/files/FileUpdater.js
@@ -43,10 +43,11 @@ export default class FileUpdater {
         let primaryStream = { duration: 0 };
 
         for (const stream of streams) {
-            if (stream.duration || 1 >= primaryStream.duration) {
-                if (stream['codec_type'] !=='video')
-                    continue;
+            if (stream['codec_type'] !== 'video')
+                continue;
 
+            if (stream.duration !== undefined &&
+                stream.duration >= primaryStream.duration) {
                 primaryStream = stream;
             }
         }
@@ -59,10 +60,11 @@ export default class FileUpdater {
         let primaryStream = { duration: 0 };
 
         for (const stream of streams) {
-            if (stream.duration || 1 >= primaryStream.duration) {
-                if (stream['codec_type'] !=='audio')
-                    continue;
+            if (stream['codec_type'] !== 'audio')
+                continue;
 
+            if (stream.duration !== undefined &&
+                stream.duration >= primaryStream.duration) {
                 primaryStream = stream;
             }
         }


### PR DESCRIPTION
## Summary
- ensure video/audio primary stream checks require a valid duration

## Testing
- `npm test` *(fails: spawn guessit ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_683f8bf87d88832f96ef0d30748b5a3f