### PR TITLE
Fix comment typo

### DIFF
--- a/src/lib/embyEmulation/ServerAPI/index.js
+++ b/src/lib/embyEmulation/ServerAPI/index.js
@@ -54,7 +54,7 @@ export default class EmbyServerAPI {
             console.log(request.url, request.params, request.method);
         });
 
-        // Add routes routes
+        // Add routes
         routes(this.server, this.embyEmulation);
 
         // Start restify server

--- a/src/submodules/REST/index.js
+++ b/src/submodules/REST/index.js
@@ -31,7 +31,7 @@ export default class OblectoAPI {
         this.server.use(restify.plugins.queryParser({ mapParams: true }));
         this.server.use(restify.plugins.bodyParser({ mapParams: true }));
 
-        // Add routes routes
+        // Add routes
         routes(this.server, this.oblecto);
 
         // Start restify server


### PR DESCRIPTION
## Summary
- fix duplicate word in REST route comments

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8c0c2c3c832fb0f17ca7a4bc65cb