### PR TITLE
Fix recode streamer premature termination

### DIFF
--- a/src/lib/streamSessions/StreamSessionTypes/RecodeStreamSession.js
+++ b/src/lib/streamSessions/StreamSessionTypes/RecodeStreamSession.js
@@ -125,7 +125,10 @@ export default class RecodeStreamSession extends StreamSession {
             logger.log('ERROR', this.sessionId, err);
         });
 
-        this.process.pipe(this.destinations[0].stream, { end: true });
+        // Pipe the transcoded output to the session output stream instead of
+        // directly to the first destination. This prevents the ffmpeg process
+        // from being terminated when a client disconnects prematurely.
+        this.process.pipe(this.outputStream, { end: true });
     }
 
     outputPause() {


### PR DESCRIPTION
## Summary
- pipe ffmpeg output through `outputStream` in recode session

## Testing
- `npm test` *(fails: spawn guessit ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68403801d8c0832fb5aa47da9bfdf3e7