### PR TITLE
Fix caching condition in TvdbEpisodeIdentifier

### DIFF
--- a/src/lib/indexers/series/identifiers/TvdbEpisodeIdentifier.js
+++ b/src/lib/indexers/series/identifiers/TvdbEpisodeIdentifier.js
@@ -23,7 +23,7 @@ export default class TvdbEpisodeIdentifier extends EpisodeIdentifier {
             return this.episodeCache[tvdbId];
         }
 
-        if (this.episodeCache.length > 100) this.episodeCache = {};
+        if (Object.keys(this.episodeCache).length > 100) this.episodeCache = {};
 
         this.episodeCache[tvdbId] = await promiseTimeout(this.oblecto.tvdb.getEpisodesBySeriesId(tvdbId));
 


### PR DESCRIPTION
## Summary
- fix episode cache length check in TvdbEpisodeIdentifier

## Testing
- `npm test` *(fails: ERR_FR_TOO_MANY_REDIRECTS, guessit ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6840a2a50484832f822a6b2c406dc966